### PR TITLE
[CLEARFACTS-6949] update to php 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 !bin/cf-codestyle*
 .php-cs-fixer.dist.php
 !templates/cs/.php-cs-fixer.dist.php
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "package",
     "description": "Provides integration with php codesniffer for your symfony projects",
     "require": {
-        "php": ">=7.0",
+        "php": "^8.1",
         "friendsofphp/php-cs-fixer": "^3.0|^2.0",
         "symfony/console": "^5.0|^4.0|^3.0",
         "symfony/filesystem": "^5.0|^4.0|^3.0",
@@ -11,7 +11,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "symfony/test-pack": "^1.0"
+        "symfony/test-pack": "^1.0",
+        "vimeo/psalm": "^4.23"
     },
     "autoload": {
         "psr-4": {
@@ -28,7 +29,6 @@
         "copy-cs-config": "bin/cf-codestyle clearfacts:codestyle:copy-cs-config"
     },
     "config": {
-        "bin-dir": "bin",
         "sort-packages": true
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+    colors="true"
+    bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="5"
+    resolveFromConfigFile="true"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/templates/cs/.php-cs-fixer-8.1.dist.php
+++ b/templates/cs/.php-cs-fixer-8.1.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create();
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'php_unit_method_casing' => ['case' => 'camel_case'],
+        'phpdoc_to_comment' => false,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
+        'no_unused_imports' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/tests/Command/CopyCsConfigCommandTest.php
+++ b/tests/Command/CopyCsConfigCommandTest.php
@@ -8,6 +8,7 @@ use Clearfacts\Bundle\CodestyleBundle\Command\CopyCsConfigCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use PhpCsFixer\Config;
 
 class CopyCsConfigCommandTest extends TestCase
 {
@@ -43,11 +44,11 @@ class CopyCsConfigCommandTest extends TestCase
         // Then
         $commandTester->assertCommandIsSuccessful();
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Preparing to copy cs config', $output);
-        $this->assertStringContainsString('[OK] Copied cs config', $output);
-        $this->assertTrue(file_exists(self::PHPCS_PATH));
-        $this->assertTrue(file_exists(self::ESLINT_PATH));
-        $this->assertStringContainsString('PhpCsFixer\Config', file_get_contents(self::PHPCS_PATH));
-        $this->assertStringContainsString('eslint:recommended', file_get_contents(self::ESLINT_PATH));
+        $this->assertStringContainsString('[OK] Copied phpcs config', $output);
+        $this->assertStringContainsString('[OK] Copied eslint config', $output);
+        $this->assertFileExists(self::PHPCS_PATH);
+        $this->assertFileExists(self::ESLINT_PATH);
+        $this->assertStringContainsString(Config::class, file_get_contents(self::PHPCS_PATH));
+        $this->assertStringContainsString('"rules": {', file_get_contents(self::ESLINT_PATH));
     }
 }

--- a/tests/Command/SetupGitHooksCommandTest.php
+++ b/tests/Command/SetupGitHooksCommandTest.php
@@ -41,14 +41,13 @@ class SetupGitHooksCommandTest extends TestCase
         // Then
         $commandTester->assertCommandIsSuccessful();
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Preparing git-hooks', $output);
         $this->assertStringContainsString('[OK] Custom hooks copied', $output);
         $this->assertStringContainsString('[OK] Default hooks copied', $output);
-        $this->assertTrue(file_exists(self::GIT_HOOKS_PATH . 'pre-commit'));
-        $this->assertTrue(file_exists(self::GIT_HOOKS_PATH . 'pre-commit-phpcs'));
-        $this->assertTrue(file_exists(self::GIT_HOOKS_PATH . 'pre-commit-eslint'));
-        $this->assertTrue(file_exists(self::GIT_HOOKS_PATH . 'pre-commit-twig'));
-        $this->assertTrue(file_exists(self::GIT_HOOKS_PATH . 'test-hook'));
+        $this->assertFileExists(self::GIT_HOOKS_PATH . 'pre-commit');
+        $this->assertFileExists(self::GIT_HOOKS_PATH . 'pre-commit-phpcs');
+        $this->assertFileExists(self::GIT_HOOKS_PATH . 'pre-commit-eslint');
+        $this->assertFileExists(self::GIT_HOOKS_PATH . 'pre-commit-twig');
+        $this->assertFileExists(self::GIT_HOOKS_PATH . 'test-hook');
         $this->assertStringContainsString('test-hook', file_get_contents(self::GIT_HOOKS_PATH . '/pre-commit'));
     }
 


### PR DESCRIPTION
- use 8.1 docker image in Makefile
- remove option to download php-cs config from github main branch directly: always use local package version
- add psalm

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>