### PR TITLE
Disable phpdoc emptylines between different tags

### DIFF
--- a/templates/cs/.php-cs-fixer-8.1.dist.php
+++ b/templates/cs/.php-cs-fixer-8.1.dist.php
@@ -10,6 +10,7 @@ return (new PhpCsFixer\Config())
         'concat_space' => ['spacing' => 'one'],
         'php_unit_method_casing' => ['case' => 'camel_case'],
         'phpdoc_to_comment' => false,
+        'phpdoc_separation' => false,
         'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters', 'match']],
         'no_unused_imports' => true,
         'heredoc_indentation' => true,


### PR DESCRIPTION

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>